### PR TITLE
Make refresher plugin to be aware of itself

### DIFF
--- a/addons/godot-plugin-refresher/plugin_refresher.gd
+++ b/addons/godot-plugin-refresher/plugin_refresher.gd
@@ -1,9 +1,6 @@
 tool
 extends HBoxContainer
 
-const ADDONS_PATH = "res://addons/"
-const PLUGIN_PATH = "godot-plugin-refresher"
-
 signal request_refresh_plugin(p_name)
 signal confirm_refresh_plugin(p_name)
 
@@ -11,20 +8,13 @@ onready var options = $OptionButton
 
 func _ready():
 	$RefreshButton.icon = get_icon('Reload', 'EditorIcons')
-	reload_items()
 
-func reload_items():
+func update_items(p_plugins):
 	if not options:
 		return
-	var dir = Directory.new()
-	dir.change_dir(ADDONS_PATH)
-	dir.list_dir_begin(true, true)
-	var file = dir.get_next()
 	options.clear()
-	while file:
-		if dir.dir_exists(ADDONS_PATH.plus_file(file)) and file != PLUGIN_PATH:
-			options.add_item(file)
-		file = dir.get_next()
+	for plugin_name in p_plugins:
+		options.add_item(plugin_name)
 
 func select_plugin(p_name):
 	if not options:

--- a/addons/godot-plugin-refresher/plugin_refresher.tscn
+++ b/addons/godot-plugin-refresher/plugin_refresher.tscn
@@ -21,7 +21,6 @@ rect_min_size = Vector2( 150, 0 )
 margin_left = 162.0
 margin_right = 174.0
 margin_bottom = 40.0
-[connection signal="pressed" from="RefreshButton" to="." method="_on_RefreshButton_pressed"]
 
 [node name="ConfirmationDialog" type="ConfirmationDialog" parent="."]
 margin_right = 278.0
@@ -29,4 +28,5 @@ margin_bottom = 110.0
 rect_min_size = Vector2( 300, 70 )
 window_title = "Plugin Refresher"
 dialog_autowrap = true
+[connection signal="pressed" from="RefreshButton" to="." method="_on_RefreshButton_pressed"]
 [connection signal="confirmed" from="ConfirmationDialog" to="." method="_on_ConfirmationDialog_confirmed"]


### PR DESCRIPTION
This removes the need for hardcoding the refresher plugin directory name for the purposes of exclucing it from the list of available plugins. Instead, the refresher plugin directory path is determined by its script path which uniquely identifies it among other plugins.

I've also renamed `godot-plugin-refresher` to `plugin_refresher` which was actually the actual reason for me doing this. It's not possible to rename the plugin directory without also changing the plugin name via code.