### PR TITLE
Display plugin names as seen in `plugin.cfg` by default

### DIFF
--- a/addons/godot-plugin-refresher/plugin_refresher.gd
+++ b/addons/godot-plugin-refresher/plugin_refresher.gd
@@ -13,8 +13,12 @@ func update_items(p_plugins):
 	if not options:
 		return
 	options.clear()
-	for plugin_name in p_plugins:
-		options.add_item(plugin_name)
+	var plugin_dirs = p_plugins.keys()
+	for idx in plugin_dirs.size():
+		var plugin_dirname = plugin_dirs[idx]
+		var plugin_name = p_plugins[plugin_dirname]
+		options.add_item(plugin_name, idx)
+		options.set_item_metadata(idx, plugin_dirname)
 
 func select_plugin(p_name):
 	if not options:
@@ -23,7 +27,7 @@ func select_plugin(p_name):
 		return
 
 	for idx in options.get_item_count():
-		var plugin = options.get_item_text(idx)
+		var plugin = options.get_item_metadata(idx)
 		if plugin == p_name:
 			options.selected = options.get_item_id(idx)
 			break
@@ -32,7 +36,7 @@ func _on_RefreshButton_pressed():
 	if options.selected == -1:
 		return # nothing selected
 
-	var plugin = options.get_item_text(options.selected)
+	var plugin = options.get_item_metadata(options.selected)
 	if not plugin or plugin.empty():
 		return
 	emit_signal("request_refresh_plugin", plugin)
@@ -45,5 +49,5 @@ func show_warning(p_name):
 	$ConfirmationDialog.popup_centered()
 
 func _on_ConfirmationDialog_confirmed():
-	var plugin = options.get_item_text(options.selected)
+	var plugin = options.get_item_metadata(options.selected)
 	emit_signal('confirm_refresh_plugin', plugin)


### PR DESCRIPTION
Closes #9.

Plugins are retained within dictionaries mapping the plugin directory name to plugin name as seen in `plugin.cfg`.

Each item within a list holds the directory name as metadata now.

The refresher plugin also checks the validity of plugins now (they must have `plugin.cfg` created).

In case of duplicate names, the directory names are displayed in parenthesis.
